### PR TITLE
Use center for way pois

### DIFF
--- a/src/extract.cc
+++ b/src/extract.cc
@@ -14,8 +14,10 @@
 #include "osmium/io/xml_input.hpp"
 
 #include "utl/enumerate.h"
+#include "utl/erase_if.h"
 #include "utl/helpers/algorithm.h"
 #include "utl/parallel_for.h"
+#include "utl/pipes/sum.h"
 #include "utl/progress_tracker.h"
 #include "utl/timer.h"
 #include "utl/timing.h"
@@ -67,7 +69,21 @@ struct feature_handler : public osmium::handler::Handler {
             r_.add_street(ctx_, street, w);
           }
         } else {
-          t_.add_place(ctx_, w.id(), true, tags, w.nodes().front().location());
+          auto const center =
+              w.ends_have_same_id()
+                  ? std::transform_reduce(
+                        w.nodes().begin(), w.nodes().end(),
+                        osm::Location{0.0, 0.0},
+                        [](auto const& a, auto const& b) {
+                          return osm::Location{a.x() + b.x(), a.y() + b.y()};
+                        },
+                        [&](auto const& l) {
+                          auto const n = static_cast<int32_t>(w.nodes().size());
+                          return osm::Location{l.location().x() / n,
+                                               l.location().y() / n};
+                        })
+                  : w.nodes()[w.nodes().size() / 2].location();
+          t_.add_place(ctx_, w.id(), true, tags, center);
         }
         t_.add_address(ctx_, tags, w.nodes().front().location());
       }


### PR DESCRIPTION
An attempt at using the center of way pois instead of a random node, to avoid something like that:
![image](https://github.com/user-attachments/assets/b26dd5e9-695e-47e7-b5fe-ff28ce6baaa3)
when using https://www.openstreetmap.org/way/178167136 as the destination.

But then, other issues occur:
![image](https://github.com/user-attachments/assets/c2ca3395-500f-4090-ae55-e465f6ea4419)

Also before:
![image](https://github.com/user-attachments/assets/b9f6bf30-6aa0-4db2-9aa7-3cdc75ed8458)
After:
![image](https://github.com/user-attachments/assets/576f9307-3e95-4a1e-bcd1-6199547b2b87)

So probably we need to find another solution...
