### PR TITLE
Country resolution 

### DIFF
--- a/include/adr/area_database.h
+++ b/include/adr/area_database.h
@@ -2,6 +2,7 @@
 
 #include <filesystem>
 #include <memory>
+#include <optional>
 
 #include "cista/mmap.h"
 
@@ -22,6 +23,7 @@ struct area_database final {
   void lookup(typeahead const&, coordinates, basic_string<area_idx_t>&) const;
   void add_area(area_idx_t, osmium::Area const&);
   bool is_within(coordinates, area_idx_t) const;
+  std::optional<coordinates> representative_point(area_idx_t) const;
 
   struct impl;
   std::unique_ptr<impl> impl_;

--- a/include/adr/typeahead.h
+++ b/include/adr/typeahead.h
@@ -65,6 +65,8 @@ struct typeahead {
   void build_ngram_index();
   bool verify();
 
+  void propagate_country_codes(struct area_database const& area_db);
+
   area_set_idx_t get_or_create_area_set(import_context&,
                                         basic_string_view<area_idx_t>);
 

--- a/src/area_database.cc
+++ b/src/area_database.cc
@@ -246,4 +246,30 @@ bool area_database::is_within(coordinates const c, area_idx_t area) const {
   return impl_->is_within(c, area);
 }
 
+std::optional<coordinates> area_database::representative_point(
+    area_idx_t const area) const {
+  auto const i = to_idx(area);
+  if (i >= impl_->outer_rings_.size()) {
+    return std::nullopt;
+  }
+  auto const& outers = impl_->outer_rings_[area];
+  if (outers.size() == 0U) {
+    return std::nullopt;
+  }
+  auto const& first_ring = outers[0U];
+  if (first_ring.size() == 0U) {
+    return std::nullopt;
+  }
+  auto const count =
+      static_cast<unsigned>((std::min)(first_ring.size(), std::size_t{8U}));
+  double lat_sum = 0.0;
+  double lng_sum = 0.0;
+  for (auto j = 0U; j < count; ++j) {
+    lat_sum += static_cast<double>(first_ring[j].lat_);
+    lng_sum += static_cast<double>(first_ring[j].lng_);
+  }
+  return coordinates{.lat_ = static_cast<std::int32_t>(lat_sum / count),
+                     .lng_ = static_cast<std::int32_t>(lng_sum / count)};
+}
+
 }  // namespace adr

--- a/src/extract.cc
+++ b/src/extract.cc
@@ -241,6 +241,11 @@ void extract(std::filesystem::path const& in_path,
   //    std::cout << k << ": " << v << "\n";
   //  }
 
+  {
+    auto const timer = utl::scoped_timer{"propagate country codes"};
+    t.propagate_country_codes(area_db);
+  }
+
   {  // Copy data from context to typeahead (not possible before, because vecvec
      // requires to build indices 0, ..., N in order).
     UTL_START_TIMING(copy_data);

--- a/src/typeahead.cc
+++ b/src/typeahead.cc
@@ -1,5 +1,7 @@
 #include "adr/typeahead.h"
 
+#include <algorithm>
+#include <iostream>
 #include <string_view>
 
 #include "cista/io.h"
@@ -15,6 +17,7 @@
 #include "osmium/geom/haversine.hpp"
 
 #include "adr/adr.h"
+#include "adr/area_database.h"
 #include "adr/guess_context.h"
 #include "adr/import_context.h"
 #include "adr/trace.h"
@@ -192,6 +195,71 @@ area_idx_t typeahead::add_admin_area(import_context& ctx,
   area_admin_level_.emplace_back(admin_level_t{admin_lvl_int});
 
   return idx;
+}
+
+void typeahead::propagate_country_codes(area_database const& area_db) {
+  auto const n = area_country_code_.size();
+  if (n == 0U) {
+    return;
+  }
+
+  auto count_missing = [&]() {
+    unsigned m = 0U;
+    for (auto i = 0U; i < n; ++i) {
+      auto const a = area_idx_t{i};
+      if (area_country_code_[a] == kNoCountryCode &&
+          area_admin_level_[a] != kPostalCodeAdminLevel &&
+          area_admin_level_[a] != kTimezoneAdminLevel) {
+        ++m;
+      }
+    }
+    return m;
+  };
+
+  auto const initial_missing = count_missing();
+  std::clog << "propagate_country_codes: " << n << " areas total, "
+            << initial_missing << " without country code\n";
+
+  // Iterative spatial containment: for each area still missing a country code,
+  // compute a representative point and use area_db (R-tree + tg point-in-polygon)
+  // to find enclosing areas. Newly resolved areas become donors for subsequent
+  // passes, propagating from coarse (admin_level 2-4) to fine (8-11).
+  unsigned total_spatial = 0U;
+  for (unsigned pass = 0U; pass < 6U; ++pass) {
+    unsigned propagated = 0U;
+    basic_string<area_idx_t> lookup_results;
+    for (auto i = 0U; i < n; ++i) {
+      auto const a = area_idx_t{i};
+      if (area_country_code_[a] != kNoCountryCode ||
+          area_admin_level_[a] == kPostalCodeAdminLevel ||
+          area_admin_level_[a] == kTimezoneAdminLevel) {
+        continue;
+      }
+      auto const rep = area_db.representative_point(a);
+      if (!rep.has_value()) {
+        continue;
+      }
+      area_db.lookup(*this, *rep, lookup_results);
+      for (auto const parent : lookup_results) {
+        if (area_country_code_[parent] != kNoCountryCode) {
+          area_country_code_[a] = area_country_code_[parent];
+          ++propagated;
+          break;
+        }
+      }
+    }
+    total_spatial += propagated;
+    std::clog << "  spatial pass " << pass << ": " << propagated
+              << " areas resolved\n";
+    if (propagated == 0U) {
+      break;
+    }
+  }
+
+  auto const final_missing = count_missing();
+  std::clog << "propagate_country_codes: spatial=" << total_spatial
+            << ", remaining=" << final_missing
+            << " (was " << initial_missing << ")\n";
 }
 
 timezone_idx_t typeahead::get_or_create_timezone(import_context& ctx,

--- a/src/typeahead.cc
+++ b/src/typeahead.cc
@@ -151,11 +151,42 @@ area_idx_t typeahead::add_admin_area(import_context& ctx,
   area_timezone_.emplace_back(tz == nullptr ? timezone_idx_t::invalid()
                                             : get_or_create_timezone(ctx, tz));
 
-  auto const c = tags["ISO3166-1"];
-  area_country_code_.emplace_back(
-      (c == nullptr || std::string_view{c}.size() < 2U)
-          ? kNoCountryCode
-          : country_code_t{c[0], c[1]});
+  // Derive a country code as robustly as possible.
+  // Some datasets (or some preprocessing steps) can miss admin_level=2 "country"
+  // boundaries, which often removes `ISO3166-1` from the remaining areas.
+  // In that case, we fall back to `ISO3166-2` (e.g. FR-75, CH-ZH) by taking
+  // the prefix before the '-'.
+  auto country_code = kNoCountryCode;
+
+  auto const c1 = tags["ISO3166-1"];
+  if (c1 != nullptr && std::string_view{c1}.size() >= 2U) {
+    country_code = country_code_t{c1[0], c1[1]};
+  } else {
+    auto const c2 = tags["ISO3166-2"];
+    if (c2 != nullptr) {
+      auto const iso3166_2 = std::string_view{c2};
+      auto const dash = iso3166_2.find('-');
+      if (dash != std::string_view::npos && dash >= 2U) {
+        auto const prefix = iso3166_2.substr(0, dash);
+        if (prefix.size() >= 2U) {
+          country_code = country_code_t{prefix[0], prefix[1]};
+        }
+      }
+    }
+
+    // Optional last-resort fallback for France/Switzerland.
+    if (country_code == kNoCountryCode) {
+      auto const wd = tags["wikidata"];
+      auto const wd_sv = wd == nullptr ? std::string_view{} : std::string_view{wd};
+      if (wd_sv == "Q142" || wd_sv == "Q1421107") {  // France
+        country_code = country_code_t{'F', 'R'};
+      } else if (wd_sv == "Q39") {  // Switzerland
+        country_code = country_code_t{'C', 'H'};
+      }
+    }
+  }
+
+  area_country_code_.emplace_back(country_code);
 
   auto const idx = area_idx_t{area_admin_level_.size()};
   area_admin_level_.emplace_back(admin_level_t{admin_lvl_int});


### PR DESCRIPTION
I am using Motis with osm in France and Switzerland (merged), in this extract because France has extra territories outside Europe, admin_level=2 is not fully present and prevent from guessing the country.
I made this patch to increase chances to guess the country which fix the returned data from Motis now including the country, and the address formatting of the address.
I tried many solution with the OSM, but none worked so I decided to fix country code building.

Hope you could integrate this pull request or at least the propagation mecanism.